### PR TITLE
Move package.json to repo root, add additional information

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "antlr4",
+  "version": "4.5.0",
+  "description": "JavaScript runtime for ANTLR4",
+  "main": "src/antlr4/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/antlr/antlr4-javascript.git"
+  },
+  "keywords": [
+    "lexer",
+    "parser",
+    "antlr",
+    "antlr4",
+    "grammar"
+  ],
+  "license": "BSD",
+  "bugs": {
+    "url": "https://github.com/antlr/antlr4-javascript/issues"
+  },
+  "homepage": "https://github.com/antlr/antlr4-javascript"
+}

--- a/src/antlr4/package.json
+++ b/src/antlr4/package.json
@@ -1,6 +1,0 @@
-{
-	"name" : "antlr4",
-	"description" : "JavaScript runtime for ANTLR4",
-	"keywords" : [ "lexer", "parser", "antlr", "grammar"],
-	"version" : "4.5.0"
-}


### PR DESCRIPTION
This PR moves `package.json` to the repo root, which is required for use with NPM, and adds some additional information to `package.json`.

Once merged into the main repo, it will enable the module to be installed by NPM with the following command:

```sh
$ npm install antlr/antlr4-javascript
```

For testing using my branch before merging you can use this command:

```sh
$ npm install 'jrunning/antlr4-javascript#fix-package-json'
```

This PR will also enable the package to be published to the NPM registry as described here: <https://docs.npmjs.com/getting-started/publishing-npm-packages>, which would close #16 and enable installation with `npm install antlr4`.